### PR TITLE
Better structure; property based tests; formatting/lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
+
+[dev-dependencies]
+quickcheck = "0.9"
+quickcheck_macros = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "lz77"
-version = "0.1.1"
+name = "konami-lz77"
+version = "0.2.0"
 authors = ["Hongjie Zhai <zhaihj@live.jp>"]
 description = "LZ77 compress/decompress in the Rust Programming Language"
-repository = "https://github.com/zhaihj/lz77-rust"
+repository = "https://github.com/zhaihj/konami-lz77"
 readme = "README.md"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ lz77 = "0.1"
 Then you are able to compress/decompress lz77 data:
 
 ```rust
-use lz77::{lz77_compress, lz77_decompress};
+use lz77::{compress, decompress};
 
 let compressed = ... // read your data here
-let decompressed = lz77_decompress(compressed, &mut decompressed);
-let recompressed = lz77_compress(decompressed, &mut recompressed);
+let decompressed = decompress(compressed, &mut decompressed);
+let recompressed = compress(decompressed, &mut recompressed);
 ```
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 Add the following line to the `dependencies` section in your `Cargo.toml` file:
 
 ```toml
-lz77 = "0.1"
+konami_lz77 = "0.2"
 ```
 
 Then you are able to compress/decompress lz77 data:
 
 ```rust
-use lz77::{compress, decompress};
+use konami_lz77::{compress, decompress};
 
 let compressed = ... // read your data here
 let decompressed = decompress(compressed, &mut decompressed);
@@ -29,3 +29,5 @@ A simple description of algorithms and basic ideas can be found [here](http://zh
 ### LICENSE
 
 MIT
+
+This crate is not affiliated with Konami.

--- a/examples/issue01.rs
+++ b/examples/issue01.rs
@@ -6,8 +6,8 @@ fn main() {
         185, 254, 185, 254, 185, 254, 185, 254, 33, 33, 33, 43, 42, 35, 38, 42, 40, 35, 38, 40, 42,
         35, 38, 40, 42, 35, 64,
     ];
-    let comp = lz77_compress(&data);
-    let dec = lz77_decompress(&comp);
+    let comp = compress(&data);
+    let dec = decompress(&comp);
 
     //assertion raised!!!!!!!
     //assert!(comp.len() < data.len());

--- a/examples/issue01.rs
+++ b/examples/issue01.rs
@@ -1,5 +1,5 @@
 extern crate lz77;
-use lz77::lz77::*;
+use lz77::*;
 
 fn main() {
     let data = [

--- a/examples/issue01.rs
+++ b/examples/issue01.rs
@@ -1,5 +1,5 @@
-extern crate lz77;
-use lz77::*;
+extern crate konami_lz77;
+use konami_lz77::*;
 
 fn main() {
     let data = [

--- a/examples/issue01.rs
+++ b/examples/issue01.rs
@@ -2,16 +2,17 @@ extern crate lz77;
 use lz77::lz77::*;
 
 fn main() {
-let data = [185 ,254 ,185 ,254 ,185 ,254 ,185 ,254 ,33
-            ,33 ,33 ,43 ,42 ,35 ,38 ,42 ,40 ,35 ,38 ,40
-            ,42 ,35 ,38 ,40 ,42 ,35 ,64];
-let comp = lz77_compress(&data);
-let dec = lz77_decompress(&comp);
+    let data = [
+        185, 254, 185, 254, 185, 254, 185, 254, 33, 33, 33, 43, 42, 35, 38, 42, 40, 35, 38, 40, 42,
+        35, 38, 40, 42, 35, 64,
+    ];
+    let comp = lz77_compress(&data);
+    let dec = lz77_decompress(&comp);
 
-//assertion raised!!!!!!!
-//assert!(comp.len() < data.len());
-println!("{} vs {}", comp.len(), data.len());
-println!("{:#?}", data);
-println!("{:#?}", comp);
-assert_eq!(data.to_vec(), dec);
+    //assertion raised!!!!!!!
+    //assert!(comp.len() < data.len());
+    println!("{} vs {}", comp.len(), data.len());
+    println!("{:#?}", data);
+    println!("{:#?}", comp);
+    assert_eq!(data.to_vec(), dec);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
 //! assert_eq!(data.to_vec(), dec);
 //! ```
 
-pub mod lz77;
+mod lz77;
+pub use lz77::{lz77_compress, lz77_compress_dummy, lz77_decompress};
 
 #[cfg(test)]
 extern crate quickcheck;
@@ -32,7 +33,7 @@ extern crate quickcheck_macros;
 
 #[cfg(test)]
 mod tests {
-    use lz77::{lz77_compress, lz77_compress_dummy, lz77_decompress};
+    use super::*;
 
     #[test]
     fn test_lz77_compress() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //! ## Example
 //!
 //! ```text
-//! extern crate lz77;
-//! use lz77::{compress, decompress};
+//! extern crate konami_lz77;
+//! use konami_lz77::{compress, decompress};
 //!
 //! let data = [0u8; 50];
 //! let comp = compress(&data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ mod tests {
         }
         {
             let mut data = [0u8; 0x80];
-            for i in 0..0x80 {
-                data[i] = i as u8 % 0x10u8;
+            for (i, byte) in data.iter_mut().enumerate() {
+                *byte = i as u8 % 0x10u8;
             }
             let comp = lz77_compress(&data);
             let dec = lz77_decompress(&comp);
@@ -55,8 +55,8 @@ mod tests {
         }
         {
             let mut data = [0u8; 0x3000];
-            for i in 0..0x3000 {
-                data[i] = i as u8 / 0x10u8;
+            for (i, byte) in data.iter_mut().enumerate() {
+                *byte = i as u8 % 0x10u8;
             }
             let comp = lz77_compress(&data);
             let dec = lz77_decompress(&comp);
@@ -81,8 +81,8 @@ mod tests {
         }
         {
             let mut data = [0u8; 0x3000];
-            for i in 0..0x3000 {
-                data[i] = i as u8 / 0x10u8;
+            for (i, byte) in data.iter_mut().enumerate() {
+                *byte = i as u8 % 0x10u8;
             }
             let comp = lz77_compress_dummy(&data);
             let dec = lz77_decompress(&comp);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 //! This package contains three functions:
 //!
 //! ```text
-//! lz77_decompress(&[u8]) -> Vec<u8> 
-//! lz77_compress(&[u8]) -> Vec<u8> 
+//! lz77_decompress(&[u8]) -> Vec<u8>
+//! lz77_compress(&[u8]) -> Vec<u8>
 //! lz77_compress_dummy(&[u8]) -> Vec<u8>
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@
 pub mod lz77;
 
 #[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
+#[cfg(test)]
 mod tests {
     use lz77::{lz77_compress, lz77_compress_dummy, lz77_decompress};
 
@@ -82,5 +88,15 @@ mod tests {
             let dec = lz77_decompress(&comp);
             assert_eq!(data.to_vec(), dec);
         }
+    }
+
+    #[quickcheck]
+    fn test_lz77_compress_prop(data: Vec<u8>) -> bool {
+        lz77_decompress(&lz77_compress(&data)) == data
+    }
+
+    #[quickcheck]
+    fn test_lz77_compress_dummy_prop(data: Vec<u8>) -> bool {
+        lz77_decompress(&lz77_compress_dummy(&data)) == data
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,27 +3,27 @@
 //! This package contains three functions:
 //!
 //! ```text
-//! lz77_decompress(&[u8]) -> Vec<u8>
-//! lz77_compress(&[u8]) -> Vec<u8>
-//! lz77_compress_dummy(&[u8]) -> Vec<u8>
+//! decompress(&[u8]) -> Vec<u8>
+//! compress(&[u8]) -> Vec<u8>
+//! compress_dummy(&[u8]) -> Vec<u8>
 //! ```
 //!
 //! ## Example
 //!
 //! ```text
 //! extern crate lz77;
-//! use lz77::{lz77_compress, lz77_decompress};
+//! use lz77::{compress, decompress};
 //!
 //! let data = [0u8; 50];
-//! let comp = lz77_compress(&data);
+//! let comp = compress(&data);
 //! let mut dec = Vec::new();
-//! let dec = lz77_decompress(&comp);
+//! let dec = decompress(&comp);
 //! assert!(comp.len() < data.len());
 //! assert_eq!(data.to_vec(), dec);
 //! ```
 
 mod lz77;
-pub use lz77::{lz77_compress, lz77_compress_dummy, lz77_decompress};
+pub use lz77::{compress, compress_dummy, decompress};
 
 #[cfg(test)]
 extern crate quickcheck;
@@ -36,11 +36,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_lz77_compress() {
+    fn test_compress() {
         {
             let data = [0u8; 50];
-            let comp = lz77_compress(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress(&data);
+            let dec = decompress(&comp);
             assert!(comp.len() < data.len());
             assert_eq!(data.to_vec(), dec);
         }
@@ -49,8 +49,8 @@ mod tests {
             for (i, byte) in data.iter_mut().enumerate() {
                 *byte = i as u8 % 0x10u8;
             }
-            let comp = lz77_compress(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress(&data);
+            let dec = decompress(&comp);
             assert!(comp.len() < data.len());
             assert_eq!(data.to_vec(), dec);
         }
@@ -59,25 +59,25 @@ mod tests {
             for (i, byte) in data.iter_mut().enumerate() {
                 *byte = i as u8 % 0x10u8;
             }
-            let comp = lz77_compress(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress(&data);
+            let dec = decompress(&comp);
             assert!(comp.len() < data.len());
             assert_eq!(data.to_vec(), dec);
         }
     }
 
     #[test]
-    fn test_lz77_compress_dummy() {
+    fn test_compress_dummy() {
         {
             let data = [0u8; 50];
-            let comp = lz77_compress_dummy(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress_dummy(&data);
+            let dec = decompress(&comp);
             assert_eq!(data.to_vec(), dec);
         }
         {
             let data = [0u8; 80];
-            let comp = lz77_compress_dummy(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress_dummy(&data);
+            let dec = decompress(&comp);
             assert_eq!(data.to_vec(), dec);
         }
         {
@@ -85,19 +85,19 @@ mod tests {
             for (i, byte) in data.iter_mut().enumerate() {
                 *byte = i as u8 % 0x10u8;
             }
-            let comp = lz77_compress_dummy(&data);
-            let dec = lz77_decompress(&comp);
+            let comp = compress_dummy(&data);
+            let dec = decompress(&comp);
             assert_eq!(data.to_vec(), dec);
         }
     }
 
     #[quickcheck]
-    fn test_lz77_compress_prop(data: Vec<u8>) -> bool {
-        lz77_decompress(&lz77_compress(&data)) == data
+    fn test_compress_prop(data: Vec<u8>) -> bool {
+        decompress(&compress(&data)) == data
     }
 
     #[quickcheck]
-    fn test_lz77_compress_dummy_prop(data: Vec<u8>) -> bool {
-        lz77_decompress(&lz77_compress_dummy(&data)) == data
+    fn test_compress_dummy_prop(data: Vec<u8>) -> bool {
+        decompress(&compress_dummy(&data)) == data
     }
 }

--- a/src/lz77.rs
+++ b/src/lz77.rs
@@ -46,7 +46,7 @@ fn match_window(window: &[u8], pos: usize, data: &[u8], dpos: usize) -> Option<(
     }
 }
 
-/// `lz77_compress` compresses the input bytes.
+/// `compress` compresses the input bytes.
 ///
 /// ## Input
 ///
@@ -56,7 +56,7 @@ fn match_window(window: &[u8], pos: usize, data: &[u8], dpos: usize) -> Option<(
 ///
 /// bytes of compressed data
 ///
-pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
+pub fn compress(input: &[u8]) -> Vec<u8> {
     let mut output = Vec::new();
     let mut window = [0u8; WINDOW_SIZE];
     let mut current_pos = 0;
@@ -125,7 +125,7 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
     output
 }
 
-/// `lz77_compress_dummy` makes the `input` valid for decompress without really compressing the data.
+/// `compress_dummy` makes the `input` valid for decompress without really compressing the data.
 ///
 /// Technically speaking, this function only inserts the `raw byte flag` to the input for every 8 bytes.
 /// as necessary.
@@ -138,7 +138,7 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
 ///
 /// bytes of raw data with 0xFF every 8 bytes.
 ///
-pub fn lz77_compress_dummy(input: &[u8]) -> Vec<u8> {
+pub fn compress_dummy(input: &[u8]) -> Vec<u8> {
     let mut output = Vec::new();
     for i in 0..input.len() / 8 {
         output.push(0xFF);
@@ -164,7 +164,7 @@ pub fn lz77_compress_dummy(input: &[u8]) -> Vec<u8> {
     output
 }
 
-/// `lz77_decompress` decompresses a compressed `input` array to raw bytes.
+/// `decompress` decompresses a compressed `input` array to raw bytes.
 ///
 /// There is no need to set the size of output. This function will adjust
 /// as necessary.
@@ -177,7 +177,7 @@ pub fn lz77_compress_dummy(input: &[u8]) -> Vec<u8> {
 ///
 /// bytes of raw data
 ///
-pub fn lz77_decompress(input: &[u8]) -> Vec<u8> {
+pub fn decompress(input: &[u8]) -> Vec<u8> {
     let mut output = Vec::new();
     let mut cur_byte = 0;
     let data_size = input.len();

--- a/src/lz77.rs
+++ b/src/lz77.rs
@@ -72,7 +72,7 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
         for bit_pos in 0..8 {
             if current_pos >= input.len() {
                 pad = 0;
-                flag_byte = flag_byte >> (8 - bit_pos);
+                flag_byte >>= 8 - bit_pos;
                 buffer[current_buffer] = 0;
                 buffer[current_buffer + 1] = 0;
                 current_buffer += 2;
@@ -103,7 +103,7 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
                 }
             }
             flag_byte = (flag_byte >> 1) | ((bit & 1u8) << 7);
-            current_window = current_window & WINDOW_MASK;
+            current_window &= WINDOW_MASK;
 
             assert!(
                 current_buffer < MAX_BUFFER,
@@ -114,8 +114,8 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
             );
         }
         output.push(flag_byte);
-        for i in 0..current_buffer {
-            output.push(buffer[i]);
+        for byte in buffer.iter().take(current_buffer) {
+            output.push(*byte);
         }
     }
     for _ in 0..pad {
@@ -152,8 +152,8 @@ pub fn lz77_compress_dummy(input: &[u8]) -> Vec<u8> {
     } else {
         let extra_bytes = input.len() % 8;
         output.push(0xFFu8 >> (8 - extra_bytes));
-        for i in input.len() - extra_bytes..input.len() {
-            output.push(input[i]);
+        for byte in input.iter().skip(input.len() - extra_bytes) {
+            output.push(*byte);
         }
         output.push(0u8);
         output.push(0u8);
@@ -208,7 +208,7 @@ pub fn lz77_decompress(input: &[u8]) -> Vec<u8> {
                     output.push(b);
                     window[window_cursor] = b;
                     window_cursor = (window_cursor + 1) & WINDOW_MASK;
-                    position = position + 1;
+                    position += 1;
                 }
             }
         }

--- a/src/lz77.rs
+++ b/src/lz77.rs
@@ -9,8 +9,11 @@ const MAX_BUFFER: usize = 0x10 + 1;
 #[inline]
 fn match_current(window: &[u8], pos: usize, max_len: usize, data: &[u8], dpos: usize) -> usize {
     let mut len = 0;
-    while dpos + len < data.len() && len < max_len &&
-          window[(pos + len) & WINDOW_MASK] == data[dpos + len] && len < MAX_LEN {
+    while dpos + len < data.len()
+        && len < max_len
+        && window[(pos + len) & WINDOW_MASK] == data[dpos + len]
+        && len < MAX_LEN
+    {
         len += 1;
     }
     len
@@ -21,11 +24,13 @@ fn match_window(window: &[u8], pos: usize, data: &[u8], dpos: usize) -> Option<(
     let mut max_pos = 0;
     let mut max_len = 0;
     for i in THRESHOLD..LOOK_RANGE {
-        let len = match_current(&window,
-                                ((pos as isize - i as isize) & WINDOW_MASK as isize) as usize,
-                                i,
-                                &data,
-                                dpos);
+        let len = match_current(
+            &window,
+            ((pos as isize - i as isize) & WINDOW_MASK as isize) as usize,
+            i,
+            &data,
+            dpos,
+        );
         if len >= INPLACE_THRESHOLD {
             return Some((i, len));
         }
@@ -41,7 +46,7 @@ fn match_window(window: &[u8], pos: usize, data: &[u8], dpos: usize) -> Option<(
     }
 }
 
-/// `lz77_compress` compresses the input bytes. 
+/// `lz77_compress` compresses the input bytes.
 ///
 /// ## Input
 ///
@@ -100,24 +105,29 @@ pub fn lz77_compress(input: &[u8]) -> Vec<u8> {
             flag_byte = (flag_byte >> 1) | ((bit & 1u8) << 7);
             current_window = current_window & WINDOW_MASK;
 
-            assert!(current_buffer < MAX_BUFFER,
-                    format!("current buffer {} > max buffer {}",
-                            current_buffer,
-                            MAX_BUFFER));
+            assert!(
+                current_buffer < MAX_BUFFER,
+                format!(
+                    "current buffer {} > max buffer {}",
+                    current_buffer, MAX_BUFFER
+                )
+            );
         }
         output.push(flag_byte);
         for i in 0..current_buffer {
             output.push(buffer[i]);
         }
     }
-    for _ in 0 .. pad { output.push(0u8); }
+    for _ in 0..pad {
+        output.push(0u8);
+    }
 
     output
 }
 
 /// `lz77_compress_dummy` makes the `input` valid for decompress without really compressing the data.
 ///
-/// Technically speaking, this function only inserts the `raw byte flag` to the input for every 8 bytes. 
+/// Technically speaking, this function only inserts the `raw byte flag` to the input for every 8 bytes.
 /// as necessary.
 ///
 /// ## Input


### PR DESCRIPTION
This PR changes the naming to avoid redundancy and to better reflect that this crate implements the konami variant of lz77. The decompression function can now be called with `konami_lz77::decompress` instead of `lz77::lz77::lz77_decompress`.

It also adds property based tests, formats the code with `rustfmt` and applies `clippy` lints.